### PR TITLE
fix: #67 tradeDurationを求める処理に使用する文字列をconfig.iniから取得する

### DIFF
--- a/application/controllers/aiTrade.go
+++ b/application/controllers/aiTrade.go
@@ -47,7 +47,7 @@ var tradeDuration int
 
 func NewAI(productCode string, duration time.Duration, pastPeriod int, UsePercent, stopLimitPercent float64, backTest bool) *AI {
 	apiClient := bitflyer.New(config.Config.ApiKey, config.Config.ApiSecret)
-	tradeDuration, _ = strconv.Atoi(strings.TrimSuffix(config.Config.TradeDuration, "m"))
+	tradeDuration, _ = strconv.Atoi(strings.TrimSuffix(config.Config.TradeDuration, config.Config.TradeSuffix))
 	var signalEvents *model.SignalEvents
 	signalEvents = model.GetSignalEventsByCount(1)
 	codes := strings.Split(productCode, "_")

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,7 @@ type ConfigList struct {
 	LogFile          string
 	ProductCode      string
 	TradeDuration    string
+	TradeSuffix      string
 	Durations        map[string]time.Duration
 	DbName           string
 	DbHost           string
@@ -47,7 +48,6 @@ func init() {
 		os.Exit(1)
 	}
 	durations := map[string]time.Duration{
-		"5m":  time.Minute * 5,
 		"15m": time.Minute * 15,
 		"30m": time.Minute * 30,
 		"1h":  time.Hour,
@@ -59,6 +59,7 @@ func init() {
 		LogFile:          cfg.Section("gotrade").Key("log_file").String(),
 		ProductCode:      cfg.Section("gotrade").Key("product_code").String(),
 		TradeDuration:    cfg.Section("gotrade").Key("trade_duration").String(),
+		TradeSuffix:      cfg.Section("gotrade").Key("trade_suffix").String(),
 		Durations:        durations,
 		DbName:           cfg.Section("db").Key("db_name").String(),
 		DbHost:           cfg.Section("db").Key("host").String(),

--- a/views/chart.html
+++ b/views/chart.html
@@ -862,7 +862,6 @@
 <body>
 
 <div>
-    <button onclick="changeDuration('5m');">5m</button>
     <button onclick="changeDuration('15m');">15m</button>
     <button onclick="changeDuration('30m');">30m</button>
     <button onclick="changeDuration('1h');">1h</button>


### PR DESCRIPTION
config.iniにtrade_suffixを追加する必要があるので、管理に少し注意が必要